### PR TITLE
Add simple version of dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
 {
-  "name": "Alpine",
+  "name": "App Container",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,10 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash"
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "editor.tabSize": 2
       },
       "extensions": [
-        "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint"
       ]
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+  "name": "Alpine",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts",
+      "pnpm": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.ssh,target=/home/node/.ssh,type=bind,consistency=cached"
+  ],
+  "postCreateCommand": "pnpm install"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 dist-ssr
 *.local
 /coverage
+.pnpm-store

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   base: "",
   plugins: [react()],
   server: {
+    host: true,
     port: PORT,
     allowedHosts: true
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import copy from "rollup-plugin-copy";
 
-const PORT = parseInt(process.env.VITE_DEV_SERVER_PORT || "3003");
+const PORT = process.env.VITE_DEV_SERVER_PORT
+  ? parseInt(process.env.VITE_DEV_SERVER_PORT)
+  : undefined;
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
A simple version of a `.devcontainer` to make local dev easier. Tested in Windows using WSL2/Ubuntu and on MacBook.